### PR TITLE
Modifies setup.cfg to resolve wheel build error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,6 @@
 # This includes the license file(s) in the wheel.
 # https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file
 license_files = LICENSE.txt
+
+[options.data_files]
+. = requirements.txt


### PR DESCRIPTION
File "/tmp/build-env-mcz8afso/lib/python3.8/site-packages/setuptools/build_meta.py", line 174, in run_setup
    exec(compile(code, __file__, 'exec'), locals())
  File "setup.py", line 6, in <module>
    with open('requirements.txt', 'r') as f:
FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'

ERROR Backend subproccess exited when trying to invoke get_requires_for_build_wheel