### PR TITLE
Downgrade matplotlib, use alternatives for axline

### DIFF
--- a/pydaddy/visualize.py
+++ b/pydaddy/visualize.py
@@ -1566,7 +1566,8 @@ class Visualize(Metrics):
     def _qq_plot(ax, residual, title):
         sigma = np.nanstd(residual)
         (osm, osr), _ = probplot(residual, sparams=(0, sigma))
-        ax.axline(xy1=(-1, -1), xy2=(1, 1), color='k')
+        ax.plot([-1, 1], [-1, 1], color='k')
+        # ax.axline(xy1=(-1, -1), xy2=(1, 1), color='k')
         ax.plot(osm, osr, '.')
 
         ax.axis('equal')
@@ -1609,7 +1610,8 @@ class Visualize(Metrics):
 
     @staticmethod
     def _km_plot(ax, km_2, km_4, title):
-        ax.axline(xy1=(0, 0), slope=1, color='k')
+        ax.plot([-1, 1], [-1, 1], color='k')
+        # ax.axline(xy1=(0, 0), slope=1, color='k')
         ax.plot(3 * (km_2 ** 2), km_4, '.')
 
         ax.axis('equal')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib>=3.4
+matplotlib>=3.2
 scipy>=1.6
 numpy>=1.20
 seaborn>=0.11


### PR DESCRIPTION
This is to ensure proper compatibility with Google Colab.
Google Colab has matplotlib v3.2.2: upgrading it requires restarting the runtime; which may be confusing to novice users.